### PR TITLE
show warning if the endpoint is NA

### DIFF
--- a/R/intrnals.R
+++ b/R/intrnals.R
@@ -13,6 +13,8 @@ function(interval)
             a <- pmin(interval[[1L]], interval[[2L]], na.rm=FALSE)
             b <- pmax(interval[[1L]], interval[[2L]], na.rm=FALSE)
         } else {
+            if (any(is.na(interval)))
+                warning("NA values where found and coerced")
             a <- pmin(interval[1L], interval[2L], na.rm=TRUE)
             b <- pmax(interval[1L], interval[2L], na.rm=TRUE)
         }


### PR DESCRIPTION
It's very prudent to show a warning before dropping NA values:

```{r}
.intrval(2, c(1, NA), "[]")
# [1] FALSE
# Warning message:
# In .get_intrval(interval) : NA values where found and coerced
```
